### PR TITLE
Update profile path handling

### DIFF
--- a/linkedin_add_ppl/browser.py
+++ b/linkedin_add_ppl/browser.py
@@ -1,4 +1,5 @@
-import os
+import platform
+from pathlib import Path
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service
 from webdriver_manager.chrome import ChromeDriverManager
@@ -10,11 +11,6 @@ class BrowserManager:
     """Utility class to configure and start or connect to a Chrome WebDriver."""
 
     def __init__(self, debug_port: int = 9222):
-
-class BrowserManager:
-    """Utility class to configure and start a Chrome WebDriver."""
-
-    def __init__(self):
         self.options = webdriver.ChromeOptions()
         self.options.add_argument("--start-maximized")
         self.options.add_argument("--log-level=3")
@@ -37,19 +33,29 @@ class BrowserManager:
 
     def choose_profile(self):
         """Ask the user for a Chrome profile and configure the options."""
-        username = os.environ.get('USERNAME')
-        user_data_dir = rf"C:\\Users\\{username}\\AppData\\Local\\Google\\Chrome\\User Data"
+        home_dir = Path.home()
+        system = platform.system()
+
+        if system == "Windows":
+            user_data_dir = home_dir / "AppData" / "Local" / "Google" / "Chrome" / "User Data"
+        elif system == "Darwin":
+            user_data_dir = home_dir / "Library" / "Application Support" / "Google" / "Chrome"
+        else:
+            user_data_dir = home_dir / ".config" / "google-chrome"
+
         self.options.add_argument(f"--user-data-dir={user_data_dir}")
-        profile_directory = input("\nEnter the Chrome profile directory name (press Enter for 'Default'): ").strip() or "Default"
-        profile_path = os.path.join(user_data_dir, profile_directory)
-        if not os.path.exists(profile_path):
+        profile_directory = (
+            input("\nEnter the Chrome profile directory name (press Enter for 'Default'): ").strip()
+            or "Default"
+        )
+        profile_path = user_data_dir / profile_directory
+        if not profile_path.exists():
             print(f"Profile '{profile_directory}' not found. Using 'Default' profile.")
             profile_directory = "Default"
         self.options.add_argument(f"--profile-directory={profile_directory}")
         print(f"Using Chrome profile: {profile_directory}\n")
 
     def start(self):
-
         """Start Chrome or attach to an existing instance."""
         if self.driver:
             return self.driver
@@ -62,6 +68,4 @@ class BrowserManager:
         self.driver = webdriver.Chrome(
             service=Service(ChromeDriverManager().install()), options=self.options
         )
-        """Launch Chrome with the configured options."""
-        self.driver = webdriver.Chrome(service=Service(ChromeDriverManager().install()), options=self.options) 
         return self.driver


### PR DESCRIPTION
## Summary
- use `Path.home` with OS detection for Chrome profile paths
- fall back to default profile when directory doesn't exist

## Testing
- `python -m py_compile linkedin_add_ppl/browser.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843a19f8b5c832baa81cfab962c7e9e